### PR TITLE
Change RES_NOTSTORED to RES_NOTFOUND

### DIFF
--- a/src/Memcached/Wrapper.php
+++ b/src/Memcached/Wrapper.php
@@ -169,8 +169,8 @@ class Wrapper
             foreach ($keys as $key) {
                 // Attempt to remove data from Memcached pool
                 if (!$this->instance()->delete($key)) {
-                    // If we were unable to remove it only care if resource was not stored
-                    if ($this->instance()->getResultCode() != Memcached::RES_NOTSTORED) {
+                    // If we were unable to remove it only care if the error wasn't RES_NOTFOUND
+                    if ($this->instance()->getResultCode() != Memcached::RES_NOTFOUND) {
                         return false;
                     }
                 }


### PR DESCRIPTION
If a key wasn't found when deleting, Memcached returns `RES_NOTFOUND`. I'm not sure that a `delete` operation would ever return `RES_NOTSTORED`.

In our case, this led to code like:

``` php
$keys = ['11211:1', '35603:1'];
$memcached->delete($keys);
```

If the key `11211:1` doesn't exist, it will prevent `35603:1` from being deleted as well, which imo, violates the principal of least surprise.
